### PR TITLE
Dockerize server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+deliverables
+requirements
+build
+out
+
+Dockerfile
+README.md
+src/module-info.java

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM java:openjdk-8
+LABEL maintainer="david@typokign.com"
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install openjfx
+
+EXPOSE 6969
+
+RUN mkdir /srv/classes
+
+WORKDIR /srv/
+ADD . .
+
+# workaround cuz I don't want to set up a build system
+RUN find -name "*.java"  > src.txt && \
+    javac @src.txt -d ./classes && \
+    jar cfe tictactoe.jar edu.saddleback.tictactoe.Main -C classes . && \
+    rm src.txt && \   
+    rm -rf classes
+
+CMD ["java", "-jar", "tictactoe.jar", "--server"]


### PR DESCRIPTION
Dockerized the server so we can easily deploy it to a server or give it to people who don't have OpenJFX or even the JDK.

If you want to test:
 - `docker build . -t tictactoe`
 - `docker run tictactoe`

Make sure the server starts and listens for a player. I wasn't able to test connecting to the server because Tomasz's branch is always creating a local server, but I'm confident it will work once Tomasz is done.